### PR TITLE
enable custom configuration for Nginx via configMapRef and change nginx default image to nginx:1.23.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WebSight Charts
-![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.6.0](https://img.shields.io/badge/AppVersion-1.6.0-informational?style=flat-square)
+![Version: 1.4.4](https://img.shields.io/badge/Version-1.4.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.19.0](https://img.shields.io/badge/AppVersion-1.19.0-informational?style=flat-square)
 
 This chart bootstraps WebSight CMS deployment on a Kubernetes cluster using the Helm package manager.
 
@@ -23,9 +23,10 @@ helm upgrade --install my-websight websight-cms \
 > WebSight instance will be available at:
 > - CMS Panel: http://cms.127.0.0.1.nip.io
 > - Demo sites:
+>   - http://kyanite.127.0.0.1.nip.io
+>   - http://luna-low-code.127.0.0.1.nip.io
 >   - http://luna.127.0.0.1.nip.io
->   - http://bulma-personal-template.127.0.0.1.nip.io
->   - http://no-code.luna.127.0.0.1.nip.io
+>   - http://luna-no-code.127.0.0.1.nip.io
 
 ### Installing the Chart
 To install the chart with the release name `my-websight` using existing domain that points to your Kubernetes cluster, run:
@@ -55,7 +56,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | cms.envsFromSecret | list | `[]` | List of WebSight CMS secrets that will work with `secretRef` |
 | cms.image.pullPolicy | string | `"IfNotPresent"` | WebSight CMS project image pull policy |
 | cms.image.repository | string | `"public.ecr.aws/ds/websight-cms-starter"` | WebSight CMS project image repository |
-| cms.image.tag | string | `"1.6.0"` | WebSight CMS project image tag |
+| cms.image.tag | string | `nil` | WebSight CMS project image tag, overwrites value from `.Chart.appVersion` |
 | cms.imagePullSecrets | list | `[]` | cms image pull secrets |
 | cms.livenessProbe.enabled | bool | `true` | enables WebSight CMS pods liveness probe |
 | cms.livenessProbe.failureThreshold | int | `3` |  |
@@ -78,7 +79,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingress.annotations | object | `{"kubernetes.io/ingress.class":"nginx","nginx.ingress.kubernetes.io/proxy-body-size":"5m"}` | custom ingress annotations |
 | ingress.enabled | bool | `false` | enables ingress |
 | ingress.hosts.cms | string | `"cms.127.0.0.1.nip.io"` | cms panel host |
-| ingress.hosts.sites | list | `["luna.127.0.0.1.nip.io","bulma-personal-template.127.0.0.1.nip.io","no-code.luna.127.0.0.1.nip.io"]` | demo sites hosts |
+| ingress.hosts.sites | list | `[]` | demo sites hosts, should correspond with your `nginx.customServerConfigurations` config |
 | mongo.env | list | `[{"name":"MONGO_INITDB_ROOT_PASSWORD","value":"mongoadmin"},{"name":"MONGO_INITDB_ROOT_USERNAME","value":"mongoadmin"}]` | MongoDB Content Store environment variables |
 | mongo.image.pullPolicy | string | `"IfNotPresent"` | MongoDB Content Store image pull policy |
 | mongo.image.repository | string | `"mongo"` | MongoDB Content Store image repository |
@@ -96,11 +97,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | mongo.resources.requests.cpu | string | `"500m"` | MongoDB request cpu resources |
 | mongo.resources.requests.memory | string | `"1Gi"` | MongoDB request memory resources |
 | mongo.storage.size | string | `"2Gi"` | MongoDB Repository volume size |
+| nginx.customServerConfigurations | list | `[]` | list of Nginx custom configs that will be atached to the container under `/etc/nginx/conf.d/` directory using `configMapRef` |
 | nginx.enabled | bool | `true` | enables Web Server |
 | nginx.env | list | `[]` | WebSight Nginx environment variables |
 | nginx.image.pullPolicy | string | `"IfNotPresent"` | Web Server image pull policy |
-| nginx.image.repository | string | `"public.ecr.aws/ds/websight-nginx-starter"` | Web Server image repository |
-| nginx.image.tag | string | `"1.6.0"` | Web Server project image tag |
+| nginx.image.repository | string | `"nginx"` | Web Server image repository |
+| nginx.image.tag | string | `"1.23.3"` | Web Server project image tag |
 | nginx.livenessProbe.enabled | bool | `true` | enables WebSight Nginx pods liveness probe |
 | nginx.livenessProbe.failureThreshold | int | `6` |  |
 | nginx.livenessProbe.initialDelaySeconds | int | `30` |  |
@@ -152,5 +154,4 @@ cms:
 
 ## Improvements (help wanted)
 
-- ingress support for cloud providers (`metadata.annotations`)
 - `*` use Community MongoDB Operator instead of custom mongo chart

--- a/websight-cms/Chart.yaml
+++ b/websight-cms/Chart.yaml
@@ -3,4 +3,4 @@ name: websight-cms
 description: This chart bootstraps WebSight CMS deployment on a Kubernetes cluster using the Helm package manager.
 type: application
 version: 1.4.4
-appVersion: "1.6.0"
+appVersion: "1.19.0"

--- a/websight-cms/README.md.gotmpl
+++ b/websight-cms/README.md.gotmpl
@@ -23,9 +23,10 @@ helm upgrade --install my-websight websight-cms \
 > WebSight instance will be available at: 
 > - CMS Panel: http://cms.127.0.0.1.nip.io
 > - Demo sites:
+>   - http://kyanite.127.0.0.1.nip.io
+>   - http://luna-low-code.127.0.0.1.nip.io
 >   - http://luna.127.0.0.1.nip.io
->   - http://bulma-personal-template.127.0.0.1.nip.io
->   - http://no-code.luna.127.0.0.1.nip.io
+>   - http://luna-no-code.127.0.0.1.nip.io
 
 ### Installing the Chart
 To install the chart with the release name `my-websight` using existing domain that points to your Kubernetes cluster, run: 
@@ -86,5 +87,4 @@ cms:
 
 ## Improvements (help wanted)
 
-- ingress support for cloud providers (`metadata.annotations`)
 - `*` use Community MongoDB Operator instead of custom mongo chart

--- a/websight-cms/sites-config/healthcheck.conf
+++ b/websight-cms/sites-config/healthcheck.conf
@@ -1,0 +1,10 @@
+server {
+    listen       80 default_server;
+    server_name  _;
+
+    location /health {
+        access_log off;
+        add_header  Content-Type    text/html;
+        return 200;
+    }
+}

--- a/websight-cms/sites-config/kyanite-site.conf
+++ b/websight-cms/sites-config/kyanite-site.conf
@@ -1,0 +1,18 @@
+server {
+    listen       80;
+    server_name  kyanite.127.0.0.1.nip.io;
+    index        Personal.html;
+
+    location /libs/kyanite/webroot {
+        root   /usr/share/nginx/html;
+    }
+
+    location ~ (.html|/)$ {
+        root   /usr/share/nginx/html/content/kyanite/pages;
+    }
+
+    location / {
+        root   /usr/share/nginx/html/content/kyanite;
+    }
+
+}

--- a/websight-cms/sites-config/lowcodeluna-site.conf
+++ b/websight-cms/sites-config/lowcodeluna-site.conf
@@ -1,0 +1,22 @@
+server {
+    listen       80;
+    server_name  luna-low-code.127.0.0.1.nip.io;
+    index        Homepage.html;
+
+    location /apps/luna/web_root {
+        root   /usr/share/nginx/html;
+    }
+
+    location /libs/kyanite/webroot {
+        root   /usr/share/nginx/html;
+    }
+
+    location ~ (.html|/)$ {
+        root   /usr/share/nginx/html/content/lowcodeluna/pages;
+    }
+
+    location / {
+        root   /usr/share/nginx/html/content/lowcodeluna;
+    }
+
+}

--- a/websight-cms/sites-config/luna-site.conf
+++ b/websight-cms/sites-config/luna-site.conf
@@ -1,0 +1,18 @@
+server {
+    listen       80;
+    server_name  luna.127.0.0.1.nip.io;
+    index        Homepage.html;
+
+    location /libs/howlite/web_root {
+        root   /usr/share/nginx/html;
+    }
+
+    location ~ (.html|/)$ {
+        root   /usr/share/nginx/html/content/luna/pages;
+    }
+
+    location / {
+        root   /usr/share/nginx/html/content/luna;
+    }
+
+}

--- a/websight-cms/sites-config/nocodeluna-site.conf
+++ b/websight-cms/sites-config/nocodeluna-site.conf
@@ -1,0 +1,18 @@
+server {
+    listen       80;
+    server_name  luna-no-code.127.0.0.1.nip.io;
+    index        Homepage.html;
+
+    location /libs/kyanite/webroot {
+        root   /usr/share/nginx/html;
+    }
+
+    location ~ (.html|/)$ {
+        root   /usr/share/nginx/html/content/nocodeluna/pages;
+    }
+
+    location / {
+        root   /usr/share/nginx/html/content/nocodeluna;
+    }
+
+}

--- a/websight-cms/templates/cms/cms-deployment.yaml
+++ b/websight-cms/templates/cms/cms-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       containers:
         - name: cms
-          image: "{{ .Values.cms.image.repository }}:{{ .Values.cms.image.tag }}"
+          image: "{{ .Values.cms.image.repository }}:{{ default .Chart.AppVersion .Values.cms.image.tag }}"
           imagePullPolicy: {{ .Values.cms.image.pullPolicy }}
           env:
             - name: MONGODB_HOST

--- a/websight-cms/templates/nginx/nginx-configmap.yaml
+++ b/websight-cms/templates/nginx/nginx-configmap.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.nginx.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: websight-cms-starter-nginx-example-config
+  labels:
+    app.kubernetes.io/name: {{ include "websight-cms.name" . }}-nginx
+    app.kubernetes.io/instance: {{ .Release.Name }}-nginx
+    app.kubernetes.io/version: {{ .Values.nginx.image.tag }}
+    app.kubernetes.io/websight-version: {{ .Chart.AppVersion }}
+    app.kubernetes.io/component: "web-server"
+    app.kubernetes.io/part-of: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+{{ (.Files.Glob "sites-config/*.conf").AsConfig | indent 2 }}
+{{- end }}

--- a/websight-cms/templates/nginx/nginx-deployment.yaml
+++ b/websight-cms/templates/nginx/nginx-deployment.yaml
@@ -47,6 +47,9 @@ spec:
             - mountPath: /usr/share/nginx/html
               name: site-repository
               readOnly: true
+            - name: nginx-config
+              mountPath: "/etc/nginx/conf.d"
+              readOnly: true
           {{- if .Values.nginx.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.nginx.livenessProbe.initialDelaySeconds }}
@@ -66,6 +69,15 @@ spec:
           persistentVolumeClaim:
             claimName: {{ include "websight-cms.fullname" . }}-site-repository
             readOnly: true
+        - name: nginx-config
+          projected:
+            sources:
+              {{- range .Values.nginx.customServerConfigurations }}
+              - configMap:
+                  name: {{ .configMapName }}
+                  items:
+{{ toYaml .configNames | indent 20 }}
+              {{- end }}
       {{- if .Values.nginx.nodeSelector }}
       nodeSelector: {{- .Values.nginx.nodeSelector | toYaml | nindent 8 }}
       {{- end }}

--- a/websight-cms/values.yaml
+++ b/websight-cms/values.yaml
@@ -6,8 +6,8 @@ cms:
   image: 
     # -- WebSight CMS project image repository
     repository: public.ecr.aws/ds/websight-cms-starter
-    # -- WebSight CMS project image tag
-    tag: 1.6.0
+    # -- WebSight CMS project image tag, overwrites value from `.Chart.appVersion`
+    tag:
     # -- WebSight CMS project image pull policy
     pullPolicy: IfNotPresent
   # -- cms image pull secrets
@@ -63,15 +63,31 @@ nginx:
   enabled: true
   image: 
     # -- Web Server image repository
-    repository: public.ecr.aws/ds/websight-nginx-starter
+    repository: nginx
     # -- Web Server project image tag
-    tag: 1.6.0
+    tag: 1.23.3
     # -- Web Server image pull policy
     pullPolicy: IfNotPresent
   # -- number of Web Server replicas
   replicas: 2
   # -- WebSight Nginx environment variables
   env: []
+  # -- list of Nginx custom configs that will be atached to the container under `/etc/nginx/conf.d/` directory using `configMapRef`
+  customServerConfigurations:
+    # @ignored in generated docs
+    - configMapName: websight-cms-starter-nginx-example-config
+      # @ignored in generated docs
+      configNames:
+        - key: healthcheck.conf
+          path: healthcheck.conf
+        - key: kyanite-site.conf
+          path: kyanite-site.conf
+        - key: lowcodeluna-site.conf
+          path: lowcodeluna-site.conf
+        - key: luna-site.conf
+          path: luna-site.conf
+        - key: nocodeluna-site.conf
+          path: nocodeluna-site.conf
   resources:
     requests:
       # -- WebSight Nginx request memory resources
@@ -86,7 +102,7 @@ nginx:
   livenessProbe:
     # -- enables WebSight Nginx pods liveness probe
     enabled: true
-    initialDelaySeconds: 30
+    initialDelaySeconds: 5
     periodSeconds: 5
     timeoutSeconds: 1
     failureThreshold: 6
@@ -103,6 +119,7 @@ siteRepository:
     size: 2Gi
   # -- (string) Configure storageClassName in case you want to use `ReadWriteMany` access mode
   rwxStorageClassName:
+
 # MongoDB Content Store configuration
 mongo:
   image: 
@@ -145,7 +162,7 @@ mongo:
   # -- (object) MongoDB node selector
   nodeSelector:
 
-# Ingress configuration
+# Ingress configuration for local development
 ingress:
   # -- enables ingress
   enabled: false
@@ -156,8 +173,13 @@ ingress:
   hosts:
     # -- cms panel host
     cms: "cms.127.0.0.1.nip.io"
-    # -- demo sites hosts
+    # -- demo sites hosts, should correspond with your `nginx.customServerConfigurations` config
     sites: 
+      # @ignored
+      - "kyanite.127.0.0.1.nip.io"
+      # @ignored
+      - "luna-low-code.127.0.0.1.nip.io"
+      # @ignored
       - "luna.127.0.0.1.nip.io"
-      - "bulma-personal-template.127.0.0.1.nip.io"
-      - "no-code.luna.127.0.0.1.nip.io"
+      # @ignored
+      - "luna-no-code.127.0.0.1.nip.io"


### PR DESCRIPTION
Changes:
- enable custom configuration for Nginx via configMapRef
- default Nginx image is `nginx:1.23.3` now (no need for custom Nginx image)
- update CMS to `1.19`
- by default, the `appVersion` is the CMS image tag now (can be overwritten)