### PR TITLE
CMS Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | cms.image.repository | string | `"europe-docker.pkg.dev/websight-io/public/websight-cms-starter"` | project image repository |
 | cms.image.tag | string | `nil` | project image tag, overwrites value from `.Chart.appVersion` |
 | cms.imagePullSecrets | list | `[]` | cms image pull secrets |
+| cms.ingress.annotations | object | `{"kubernetes.io/ingress.class":"nginx","nginx.ingress.kubernetes.io/proxy-body-size":"5m"}` | custom CMS ingress annotations |
+| cms.ingress.enabled | bool | `false` | enables CMS ingress |
+| cms.ingress.host | string | `"cms.127.0.0.1.nip.io"` | cms host |
 | cms.livenessProbe.enabled | bool | `true` | enables pods liveness probe |
 | cms.livenessProbe.failureThreshold | int | `3` |  |
 | cms.livenessProbe.initialDelaySeconds | int | `30` |  |
@@ -80,9 +83,17 @@ The command removes all the Kubernetes components associated with the chart and 
 | cms.replicas | int | `1` | number of replicas, mind that `tar` persistence mode will create a StatefulSet, while `mongo` will create a Deployment |
 | cms.resources | object | `{}` | container's resources settings |
 | cms.session.cookie | object | `{"expires":172800,"maxAge":172800}` | ingress nginx.ingress.kubernetes.io/affinity settings |
-| ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"5m"}` | custom ingress annotations |
-| ingress.enabled | bool | `false` | enables nginx ingress |
-| ingress.hosts.cms | string | `"cms.127.0.0.1.nip.io"` | cms host |
+| proxy.enabled | bool | `false` | enables proxy |
+| proxy.env | list | `[{"name":"NGINX_HOST","value":"127.0.0.1.nip.io"}]` | environment variables |
+| proxy.image | object | `{"repository":"nginx","tag":"stable-alpine"}` | proxy image repository |
+| proxy.imagePullSecrets | list | `[]` | proxy image pull secrets |
+| proxy.ingress.annotations | object | `{"kubernetes.io/ingress.class":"nginx"}` | custom ingress annotations |
+| proxy.livenessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":1}` | liveliness probe config |
+| proxy.livenessProbe.enabled | bool | `true` | enables pods liveness probe |
+| proxy.nodeSelector | object | `nil` | node selector |
+| proxy.replicas | int | `1` | number of replicas |
+| proxy.resources | object | `{}` | container's resources settings |
+| proxy.sites | object | `[]` | site configuration, see the `examples/luna-proxy` for more details |
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # WebSight Charts
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.22.1](https://img.shields.io/badge/AppVersion-1.22.1-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.23.0](https://img.shields.io/badge/AppVersion-1.23.0-informational?style=flat-square)
 
 This chart bootstraps WebSight CMS deployment on a Kubernetes cluster using the Helm package manager.
 
@@ -57,7 +57,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | cms.image.repository | string | `"europe-docker.pkg.dev/websight-io/public/websight-cms-starter"` | project image repository |
 | cms.image.tag | string | `nil` | project image tag, overwrites value from `.Chart.appVersion` |
 | cms.imagePullSecrets | list | `[]` | cms image pull secrets |
-| cms.ingress.annotations | object | `{"kubernetes.io/ingress.class":"nginx","nginx.ingress.kubernetes.io/proxy-body-size":"5m"}` | custom CMS ingress annotations |
+| cms.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"5m"}` | custom CMS ingress annotations |
 | cms.ingress.enabled | bool | `false` | enables CMS ingress |
 | cms.ingress.host | string | `"cms.127.0.0.1.nip.io"` | cms host |
 | cms.livenessProbe.enabled | bool | `true` | enables pods liveness probe |
@@ -83,6 +83,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | cms.replicas | int | `1` | number of replicas, mind that `tar` persistence mode will create a StatefulSet, while `mongo` will create a Deployment |
 | cms.resources | object | `{}` | container's resources settings |
 | cms.session.cookie | object | `{"expires":172800,"maxAge":172800}` | ingress nginx.ingress.kubernetes.io/affinity settings |
+| cms.updateStrategy | object | `{}` | update strategy, works only for `mongo` persistence mode |
 | proxy.enabled | bool | `false` | enables proxy |
 | proxy.env | list | `[{"name":"NGINX_HOST","value":"127.0.0.1.nip.io"}]` | environment variables |
 | proxy.image | object | `{"repository":"nginx","tag":"stable-alpine"}` | proxy image repository |
@@ -94,6 +95,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | proxy.replicas | int | `1` | number of replicas |
 | proxy.resources | object | `{}` | container's resources settings |
 | proxy.sites | object | `[]` | site configuration, see the `examples/luna-proxy` for more details |
+| proxy.updateStrategy | object | `{}` | update strategy |
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -85,13 +85,15 @@ The command removes all the Kubernetes components associated with the chart and 
 | cms.session.cookie | object | `{"expires":172800,"maxAge":172800}` | ingress nginx.ingress.kubernetes.io/affinity settings |
 | cms.updateStrategy | object | `{}` | update strategy, works only for `mongo` persistence mode |
 | proxy.enabled | bool | `false` | enables proxy |
-| proxy.env | list | `[{"name":"NGINX_HOST","value":"127.0.0.1.nip.io"}]` | environment variables |
+| proxy.env | list | `[]` | environment variables |
 | proxy.image | object | `{"repository":"nginx","tag":"stable-alpine"}` | proxy image repository |
 | proxy.imagePullSecrets | list | `[]` | proxy image pull secrets |
 | proxy.ingress.annotations | object | `{"kubernetes.io/ingress.class":"nginx"}` | custom ingress annotations |
 | proxy.livenessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":1}` | liveliness probe config |
 | proxy.livenessProbe.enabled | bool | `true` | enables pods liveness probe |
 | proxy.nodeSelector | object | `nil` | node selector |
+| proxy.readinessProbe | object | `{"enabled":true,"failureThreshold":3,"initialDelaySeconds":5,"periodSeconds":5,"successThreshold":1,"timeoutSeconds":1}` | readiness probe config |
+| proxy.readinessProbe.enabled | bool | `true` | enables pods readiness probe |
 | proxy.replicas | int | `1` | number of replicas |
 | proxy.resources | object | `{}` | container's resources settings |
 | proxy.sites | object | `[]` | site configuration, see the `examples/luna-proxy` for more details |
@@ -142,6 +144,30 @@ The command removes all the Kubernetes components associated with the chart and 
      --set cms.livenessProbe.initialDelaySeconds=60 \
      -n cms --create-namespace
    ```
+
+#### Running CMS with Ngninx proxy
+To run CMS with Nginx proxy you need to enable it by setting `proxy.enabled` to `true`.
+
+See the [luna-proxy](websight-cms/examples/luna-proxy) example `values.yaml` file for more details on how to configure Nginx to proxy a particular CMS site.
+
+To run the example, follow the steps below:
+1. Create `cms` namespace:
+   ```bash
+   kubectl create namespace cms
+   ```
+2. From `websight-cms` directory create Nginx proxy configuration as a ConfigMap
+   ```bash
+   kubectl create configmap luna-site-config --from-file=examples/luna-proxy/luna-site.conf.template -n cms
+   ```
+3. From `websight-cms` directory install CMS with Nginx proxy enabled:
+   ```bash
+   helm upgrade --install websight-cms . \
+     --set proxy.enabled=true \
+     --set cms.ingress.enabled=true \
+     -n cms -f examples/luna-proxy/values.yaml
+   ```
+   CMS should start in 1-2 minutes.
+   The information about available CMS Panel and Luna site should be printed.
 
 #### Custom CMS admin username and password
 

--- a/websight-cms/README.md.gotmpl
+++ b/websight-cms/README.md.gotmpl
@@ -96,6 +96,30 @@ The command removes all the Kubernetes components associated with the chart and 
      -n cms --create-namespace
    ```
 
+#### Running CMS with Ngninx proxy
+To run CMS with Nginx proxy you need to enable it by setting `proxy.enabled` to `true`.
+
+See the [luna-proxy](websight-cms/examples/luna-proxy) example `values.yaml` file for more details on how to configure Nginx to proxy a particular CMS site.
+
+To run the example, follow the steps below:
+1. Create `cms` namespace:
+   ```bash
+   kubectl create namespace cms
+   ```
+2. From `websight-cms` directory create Nginx proxy configuration as a ConfigMap
+   ```bash
+   kubectl create configmap luna-site-config --from-file=examples/luna-proxy/luna-site.conf.template -n cms
+   ```
+3. From `websight-cms` directory install CMS with Nginx proxy enabled:
+   ```bash
+   helm upgrade --install websight-cms . \
+     --set proxy.enabled=true \
+     --set cms.ingress.enabled=true \
+     -n cms -f examples/luna-proxy/values.yaml
+   ```
+   CMS should start in 1-2 minutes. 
+   The information about available CMS Panel and Luna site should be printed.
+
 #### Custom CMS admin username and password
 
 > Important!!!

--- a/websight-cms/examples/luna-proxy/luna-site.conf.template
+++ b/websight-cms/examples/luna-proxy/luna-site.conf.template
@@ -1,0 +1,23 @@
+server {
+    listen       80;
+    server_name  luna.${NGINX_HOST};
+    index        /published/luna/pages/Homepage.html;
+
+    location /published/luna {
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass http://websight-cms-cms:8080/published/luna;
+    }
+
+    location /libs {
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass http://websight-cms-cms:8080/libs;
+    }
+
+    location /apps {
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_pass http://websight-cms-cms:8080/apps;
+    }
+}

--- a/websight-cms/examples/luna-proxy/values.yaml
+++ b/websight-cms/examples/luna-proxy/values.yaml
@@ -1,0 +1,15 @@
+# Example values for websight-cms with luna site Nginx proxy
+# WebSight CMS proxy configuration
+
+proxy:
+  enabled: true
+  sites:
+    # (object) site configuration
+    - name: luna
+      # site host exposed via ingress
+      host: luna.127.0.0.1.nip.io
+      configMapKeyRef:
+        # config map name where site configuration is stored
+        name: luna-site-config
+        # config map key where site configuration template is stored, it will be mounted under the `/tmp/nginx/conf.d/<key>` path
+        key: luna-site.conf.template

--- a/websight-cms/examples/luna-proxy/values.yaml
+++ b/websight-cms/examples/luna-proxy/values.yaml
@@ -3,6 +3,11 @@
 
 proxy:
   enabled: true
+  env:
+    # environment variable used in the Nginx configuration template, read more here:
+    # https://hub.docker.com/_/nginx#:~:text=Using%20environment%20variables%20in%20nginx%20configuration
+    - name: NGINX_HOST
+      value: 127.0.0.1.nip.io
   sites:
     # (object) site configuration
     - name: luna

--- a/websight-cms/templates/NOTES.txt
+++ b/websight-cms/templates/NOTES.txt
@@ -12,4 +12,11 @@ WebSight instance will be available at:{{ ` ` }}
 Custom password and username for admin were set in the {{ .Release.Name }}-{{ .Values.cms.customAdminSecret }} secret.
 {{- end }}
 
+{{ if and (.Values.proxy.enabled) (not (empty .Values.proxy.sites))  -}}
+Sites:
+{{- range .Values.proxy.sites }}
+ - {{ .name }}: http://{{ .host }}
+{{- end }}
+{{- end }}
+
 Happy WebSight helming!

--- a/websight-cms/templates/NOTES.txt
+++ b/websight-cms/templates/NOTES.txt
@@ -3,9 +3,9 @@ Your release is named {{ .Release.Name }}.
 
 Your WebSight CE instance is starting...
 
-{{- if .Values.ingress.enabled }}
+{{- if .Values.cms.ingress.enabled }}
 WebSight instance will be available at:{{ ` ` }}
- - CMS Panel: http://{{ .Values.ingress.hosts.cms }}
+ - CMS Panel: http://{{ .Values.cms.ingress.host }}
 {{- end }}
 
 {{- if .Values.cms.customAdminSecret }}

--- a/websight-cms/templates/_helpers.tpl
+++ b/websight-cms/templates/_helpers.tpl
@@ -60,3 +60,48 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Create a default fully qualified component name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+Usage:
+{{ include "websight-cms.component.fullname" (dict "componentName" "component-name" "context" $) }}
+*/}}
+{{- define "websight-cms.component.fullname" -}}
+{{- if .context.Values.fullnameOverride }}
+{{- printf "%s-%s" .context.Values.fullnameOverride .componentName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .context.Chart.Name .context.Values.nameOverride }}
+{{- if contains $name .context.Release.Name }}
+{{- printf "%s-%s" .context.Release.Name .componentName | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s-%s" .context.Release.Name $name .componentName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Metadata labels for CMS component
+Usage:
+{{ include "websight-cms.component.labels" (dict "componentName" "component-name" "context" $) }}
+*/}}
+{{- define "websight-cms.component.labels" -}}
+helm.sh/chart: {{ include "websight-cms.chart" .context }}
+{{ include "websight-cms.component.selectorLabels" (dict "componentName" .componentName "context" .context) }}
+{{- if .context.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .context.Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .context.Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels for CMS component
+Usage:
+{{ include "websight-cms.component.selectorLabels" (dict "componentName" "component-name" "context" $) }}
+*/}}
+{{- define "websight-cms.component.selectorLabels" -}}
+{{ include "websight-cms.selectorLabels" .context }}
+app.kubernetes.io/component: {{ .componentName }}
+{{- end }}

--- a/websight-cms/templates/cms/cms-deployment.yaml
+++ b/websight-cms/templates/cms/cms-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "websight-cms.component.labels" (dict "componentName" "cms" "context" $) | nindent 4 }}
 spec:
   replicas: {{ .Values.cms.replicas }}
+  {{- if .Values.cms.updateStrategy }}
+  strategy: {{- toYaml .Values.cms.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "websight-cms.component.selectorLabels" (dict "componentName" "cms" "context" $) | nindent 6 }}

--- a/websight-cms/templates/cms/cms-deployment.yaml
+++ b/websight-cms/templates/cms/cms-deployment.yaml
@@ -2,18 +2,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "websight-cms.fullname" . }}
+  name: {{ include "websight-cms.component.fullname" (dict "componentName" "cms" "context" $) }}
   labels:
-    {{- include "websight-cms.labels" . | nindent 4 }}
+    {{- include "websight-cms.component.labels" (dict "componentName" "cms" "context" $) | nindent 4 }}
 spec:
   replicas: {{ .Values.cms.replicas }}
   selector:
     matchLabels:
-      {{- include "websight-cms.selectorLabels" . | nindent 6 }}
+      {{- include "websight-cms.component.selectorLabels" (dict "componentName" "cms" "context" $) | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "websight-cms.selectorLabels" . | nindent 8 }}
+        {{- include "websight-cms.component.selectorLabels" (dict "componentName" "cms" "context" $) | nindent 8 }}
     spec:
       {{- if .Values.cms.imagePullSecrets }}
       imagePullSecrets: {{- .Values.cms.imagePullSecrets | toYaml | nindent 8 }}

--- a/websight-cms/templates/cms/cms-ingress.yaml
+++ b/websight-cms/templates/cms/cms-ingress.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "websight-cms.component.fullname" (dict "componentName" "cms" "context" $) }}
   annotations:
     kubernetes.io/ingress.class: nginx
-    {{- if gt .Values.cms.replicas 1 }}
+    {{- if gt (.Values.cms.replicas | int) 1 }}
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "websight-cms-sticky"
     nginx.ingress.kubernetes.io/session-cookie-expires: {{ .Values.cms.session.cookie.expires | quote }}

--- a/websight-cms/templates/cms/cms-ingress.yaml
+++ b/websight-cms/templates/cms/cms-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-max-age: {{ .Values.cms.session.cookie.maxAge | quote }}
     {{- end }}
     {{- if .Values.cms.ingress.annotations }}
-    annotations: {{- .Values.cms.ingress.annotations | toYaml | nindent 4 }}
+    {{- .Values.cms.ingress.annotations | toYaml | nindent 4 }}
     {{- end }}
   labels:
     {{- include "websight-cms.component.labels" (dict "componentName" "cms" "context" $) | nindent 4 }}

--- a/websight-cms/templates/cms/cms-ingress.yaml
+++ b/websight-cms/templates/cms/cms-ingress.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.ingress.enabled -}}
+{{- if .Values.cms.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "websight-cms.component.fullname" (dict "componentName" "ingress" "context" $) }}
+  name: {{ include "websight-cms.component.fullname" (dict "componentName" "cms" "context" $) }}
   annotations:
     kubernetes.io/ingress.class: nginx
     {{- if gt .Values.cms.replicas 1 }}
@@ -11,14 +11,14 @@ metadata:
     nginx.ingress.kubernetes.io/session-cookie-expires: {{ .Values.cms.session.cookie.expires | quote }}
     nginx.ingress.kubernetes.io/session-cookie-max-age: {{ .Values.cms.session.cookie.maxAge | quote }}
     {{- end }}
-    {{- if .Values.ingress.annotations }}
-    {{- .Values.ingress.annotations | toYaml | nindent 4 }}
+    {{- if .Values.cms.ingress.annotations }}
+    annotations: {{- .Values.cms.ingress.annotations | toYaml | nindent 4 }}
     {{- end }}
   labels:
-    {{- include "websight-cms.component.labels" (dict "componentName" "ingress" "context" $) | nindent 4 }}
+    {{- include "websight-cms.component.labels" (dict "componentName" "cms" "context" $) | nindent 4 }}
 spec:
   rules:
-  - host: {{ tpl .Values.ingress.hosts.cms . }}
+  - host: {{ tpl .Values.cms.ingress.host . }}
     http:
       paths:
       - pathType: ImplementationSpecific
@@ -27,5 +27,5 @@ spec:
           service:
             name: {{ include "websight-cms.component.fullname" (dict "componentName" "cms" "context" $) }}
             port:
-              number: 8080 
+              number: 8080
 {{- end }}

--- a/websight-cms/templates/cms/cms-service.yaml
+++ b/websight-cms/templates/cms/cms-service.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "websight-cms.fullname" . }}
+  name: {{ include "websight-cms.component.fullname" (dict "componentName" "cms" "context" $) }}
   labels:
-    {{- include "websight-cms.labels" . | nindent 4 }}
+    {{- include "websight-cms.component.labels" (dict "componentName" "cms" "context" $) | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
@@ -11,4 +11,4 @@ spec:
       port: 8080
       targetPort: 8080
   selector:
-    {{- include "websight-cms.selectorLabels" . | nindent 4 }}
+    {{- include "websight-cms.component.selectorLabels" (dict "componentName" "cms" "context" $) | nindent 4 }}

--- a/websight-cms/templates/cms/cms-statefulset.yaml
+++ b/websight-cms/templates/cms/cms-statefulset.yaml
@@ -2,18 +2,18 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ include "websight-cms.fullname" . }}
+  name: {{ include "websight-cms.component.fullname" (dict "componentName" "cms" "context" $) }}
   labels:
-    {{- include "websight-cms.labels" . | nindent 4 }}
+    {{- include "websight-cms.component.labels" (dict "componentName" "cms" "context" $) | nindent 4 }}
 spec:
   replicas: {{ .Values.cms.replicas }}
   selector:
     matchLabels:
-      {{- include "websight-cms.selectorLabels" . | nindent 6 }}
+      {{- include "websight-cms.component.selectorLabels" (dict "componentName" "cms" "context" $) | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "websight-cms.selectorLabels" . | nindent 8 }}
+        {{- include "websight-cms.component.selectorLabels" (dict "componentName" "cms" "context" $) | nindent 8 }}
     spec:
       {{- if .Values.cms.imagePullSecrets }}
       imagePullSecrets: {{- .Values.cms.imagePullSecrets | toYaml | nindent 8 }}

--- a/websight-cms/templates/ingress.yaml
+++ b/websight-cms/templates/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "websight-cms.fullname" . }}-ingress
+  name: {{ include "websight-cms.component.fullname" (dict "componentName" "ingress" "context" $) }}
   annotations:
     kubernetes.io/ingress.class: nginx
     {{- if gt .Values.cms.replicas 1 }}
@@ -15,7 +15,7 @@ metadata:
     {{- .Values.ingress.annotations | toYaml | nindent 4 }}
     {{- end }}
   labels:
-    {{- include "websight-cms.labels" . | nindent 4 }}
+    {{- include "websight-cms.component.labels" (dict "componentName" "ingress" "context" $) | nindent 4 }}
 spec:
   rules:
   - host: {{ tpl .Values.ingress.hosts.cms . }}
@@ -25,7 +25,7 @@ spec:
         path: "/"
         backend:
           service:
-            name: {{ include "websight-cms.fullname" . }}
+            name: {{ include "websight-cms.component.fullname" (dict "componentName" "cms" "context" $) }}
             port:
               number: 8080 
 {{- end }}

--- a/websight-cms/templates/proxy/proxy-default-configs.yaml
+++ b/websight-cms/templates/proxy/proxy-default-configs.yaml
@@ -18,5 +18,5 @@ data:
         }
     }
   10-include-tmp.conf: |-
-    include /tmp/proxy/conf.d/*;
+    include /tmp/nginx/conf.d/*;
 {{- end }}

--- a/websight-cms/templates/proxy/proxy-default-configs.yaml
+++ b/websight-cms/templates/proxy/proxy-default-configs.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.proxy.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "websight-cms.component.fullname" (dict "componentName" "proxy-default-configs" "context" $) }}
+  labels:
+    {{- include "websight-cms.component.labels" (dict "componentName" "proxy" "context" $) | nindent 4 }}
+data:
+  healthcheck.conf: |-
+    server {
+        listen       80 default_server;
+        server_name  _;
+  
+        location /health {
+            access_log off;
+            add_header  Content-Type    text/html;
+            return 200;
+        }
+    }
+  10-include-tmp.conf: |-
+    include /tmp/proxy/conf.d/*;
+{{- end }}

--- a/websight-cms/templates/proxy/proxy-deployment.yaml
+++ b/websight-cms/templates/proxy/proxy-deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- include "websight-cms.component.labels" (dict "componentName" "proxy" "context" $) | nindent 4 }}
 spec:
   replicas: {{ .Values.proxy.replicas }}
+  {{- if .Values.proxy.updateStrategy }}
+  strategy: {{- toYaml .Values.proxy.updateStrategy | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "websight-cms.component.selectorLabels" (dict "componentName" "proxy" "context" $) | nindent 6 }}

--- a/websight-cms/templates/proxy/proxy-deployment.yaml
+++ b/websight-cms/templates/proxy/proxy-deployment.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.proxy.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "websight-cms.component.fullname" (dict "componentName" "proxy" "context" $) }}
+  labels:
+    {{- include "websight-cms.component.labels" (dict "componentName" "proxy" "context" $) | nindent 4 }}
+spec:
+  replicas: {{ .Values.proxy.replicas }}
+  selector:
+    matchLabels:
+      {{- include "websight-cms.component.selectorLabels" (dict "componentName" "proxy" "context" $) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "websight-cms.component.selectorLabels" (dict "componentName" "proxy" "context" $) | nindent 8 }}
+    spec:
+      {{- if .Values.proxy.imagePullSecrets }}
+      imagePullSecrets: {{- .Values.proxy.imagePullSecrets | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: nginx
+          image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
+          imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
+          env:
+            - name: NGINX_HOST
+              value: {{ .Values.proxy.host }}
+            - name: NGINX_ENVSUBST_OUTPUT_DIR
+              value: /tmp/nginx/conf.d
+            {{- range $k, $v := .Values.proxy.env }}
+            - name: {{ $v.name }}
+              value: {{ $v.value | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: 80
+          {{- if .Values.proxy.resources }}
+          resources:
+{{ toYaml .Values.proxy.resources | indent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: tmp-config
+              mountPath: /tmp/nginx/conf.d
+            - name: nginx-config
+              mountPath: "/etc/nginx/conf.d"
+              readOnly: true
+            - name: nginx-config-templates
+              mountPath: "/etc/nginx/templates"
+              readOnly: true
+          {{- if .Values.proxy.livenessProbe.enabled }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.proxy.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.proxy.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.proxy.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.proxy.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.proxy.livenessProbe.successThreshold }}
+            httpGet:
+              path: /health
+              port: 80
+              scheme: HTTP
+          {{- end }}
+      volumes:
+        - name: tmp-config
+          emptyDir:
+            medium: Memory
+            sizeLimit: 2Mi
+        - name: nginx-config
+          projected:
+            sources:
+              - configMap:
+                  name: {{ include "websight-cms.component.fullname" (dict "componentName" "proxy-default-configs" "context" $) }}
+                  items:
+                    - key: healthcheck.conf
+                      path: healthcheck.conf
+                    - key: 10-include-tmp.conf
+                      path: 10-include-tmp.conf
+              {{- range .Values.proxy.customServerConfigurations }}
+              - configMap:
+                  name: {{ .configMapName }}
+                  items:
+{{ toYaml .configNames | indent 20 }}
+              {{- end }}
+        - name: nginx-config-templates
+          projected:
+            sources:
+              {{- range .Values.proxy.configurationTemplates }}
+              - configMap:
+                  name: {{ .configMapName }}
+                  items:
+{{ toYaml .configNames | indent 20 }}
+              {{- end }}
+      {{- if .Values.proxy.nodeSelector }}
+      nodeSelector: {{- .Values.proxy.nodeSelector | toYaml | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/websight-cms/templates/proxy/proxy-deployment.yaml
+++ b/websight-cms/templates/proxy/proxy-deployment.yaml
@@ -60,6 +60,18 @@ spec:
               port: 80
               scheme: HTTP
           {{- end }}
+          {{- if .Values.proxy.readinessProbe.enabled }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.proxy.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.proxy.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.proxy.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.proxy.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.proxy.readinessProbe.successThreshold }}
+            httpGet:
+              path: /health
+              port: 80
+              scheme: HTTP
+          {{- end }}
       volumes:
         - name: tmp-config
           emptyDir:

--- a/websight-cms/templates/proxy/proxy-deployment.yaml
+++ b/websight-cms/templates/proxy/proxy-deployment.yaml
@@ -23,8 +23,6 @@ spec:
           image: "{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
           imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
           env:
-            - name: NGINX_HOST
-              value: {{ .Values.proxy.host }}
             - name: NGINX_ENVSUBST_OUTPUT_DIR
               value: /tmp/nginx/conf.d
             {{- range $k, $v := .Values.proxy.env }}
@@ -74,20 +72,15 @@ spec:
                       path: healthcheck.conf
                     - key: 10-include-tmp.conf
                       path: 10-include-tmp.conf
-              {{- range .Values.proxy.customServerConfigurations }}
-              - configMap:
-                  name: {{ .configMapName }}
-                  items:
-{{ toYaml .configNames | indent 20 }}
-              {{- end }}
         - name: nginx-config-templates
           projected:
             sources:
-              {{- range .Values.proxy.configurationTemplates }}
+              {{- range .Values.proxy.sites }}
               - configMap:
-                  name: {{ .configMapName }}
+                  name: {{ .configMapKeyRef.name }}
                   items:
-{{ toYaml .configNames | indent 20 }}
+                    - key: {{ .configMapKeyRef.key }}
+                      path: {{ .configMapKeyRef.key }}
               {{- end }}
       {{- if .Values.proxy.nodeSelector }}
       nodeSelector: {{- .Values.proxy.nodeSelector | toYaml | nindent 8 }}

--- a/websight-cms/templates/proxy/proxy-ingress.yaml
+++ b/websight-cms/templates/proxy/proxy-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.proxy.enabled) (not (empty .Values.proxy.ingress.sites))  -}}
+{{- if and (.Values.proxy.enabled) (not (empty .Values.proxy.sites))  -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -10,8 +10,8 @@ metadata:
     {{- include "websight-cms.component.labels" (dict "componentName" "proxy" "context" $) | nindent 4 }}
 spec:
   rules:
-  {{- range .Values.proxy.ingress.sites }}
-  - host: {{ tpl . $ }}
+  {{- range .Values.proxy.sites }}
+  - host: {{ .host }}
     http:
       paths:
       - pathType: Prefix

--- a/websight-cms/templates/proxy/proxy-ingress.yaml
+++ b/websight-cms/templates/proxy/proxy-ingress.yaml
@@ -1,0 +1,25 @@
+{{- if and (.Values.proxy.enabled) (not (empty .Values.proxy.ingress.sites))  -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "websight-cms.component.fullname" (dict "componentName" "proxy" "context" $) }}
+  {{- if .Values.proxy.ingress.annotations }}
+  annotations: {{- .Values.proxy.ingress.annotations | toYaml | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "websight-cms.component.labels" (dict "componentName" "proxy" "context" $) | nindent 4 }}
+spec:
+  rules:
+  {{- range .Values.proxy.ingress.sites }}
+  - host: {{ tpl . $ }}
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: {{ include "websight-cms.component.fullname" (dict "componentName" "proxy" "context" $) }}
+            port:
+              number: 80
+  {{- end }}
+{{- end }}

--- a/websight-cms/templates/proxy/proxy-service.yaml
+++ b/websight-cms/templates/proxy/proxy-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.proxy.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "websight-cms.component.fullname" (dict "componentName" "proxy" "context" $) }}
+  labels:
+    {{- include "websight-cms.component.labels" (dict "componentName" "proxy" "context" $) | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+  selector:
+    {{- include "websight-cms.component.selectorLabels" (dict "componentName" "proxy" "context" $) | nindent 4 }}
+{{- end }}

--- a/websight-cms/test-scripts/login-success.sh
+++ b/websight-cms/test-scripts/login-success.sh
@@ -3,6 +3,6 @@
 set -x
 
 # Authenticate with valid password - request should return 200
-curl -f http://websight-cms:8080/apps/websight-authentication/j_security_check \
+curl -f http://websight-cms-cms:8080/apps/websight-authentication/j_security_check \
   --data-raw '_charset_=UTF-8&resource=%2F&j_username=wsadmin&j_password=pass4test' \
   -ipv4

--- a/websight-cms/test-scripts/login-with-invalid-password.sh
+++ b/websight-cms/test-scripts/login-with-invalid-password.sh
@@ -3,6 +3,6 @@
 set -x
 
 # Authenticate with invalid password - request should return 401
-curl -s -o /dev/null -w "%{http_code}" http://websight-cms:8080/apps/websight-authentication/j_security_check \
+curl -s -o /dev/null -w "%{http_code}" http://websight-cms-cms:8080/apps/websight-authentication/j_security_check \
   --data-raw '_charset_=UTF-8&resource=%2F&j_username=wsadmin&j_password=wsadmin' \
   -ipv4 | grep '401'

--- a/websight-cms/values.yaml
+++ b/websight-cms/values.yaml
@@ -14,6 +14,8 @@ cms:
   imagePullSecrets: []
   # -- number of replicas, mind that `tar` persistence mode will create a StatefulSet, while `mongo` will create a Deployment
   replicas: 1
+  # -- update strategy, works only for `mongo` persistence mode
+  updateStrategy: {}
   session:
     # -- ingress nginx.ingress.kubernetes.io/affinity settings
     cookie:
@@ -94,6 +96,8 @@ proxy:
   imagePullSecrets: []
   # -- number of replicas
   replicas: 1
+  # -- update strategy
+  updateStrategy: {}
   # -- container's resources settings
   resources:
     # @ignored in generated docs

--- a/websight-cms/values.yaml
+++ b/websight-cms/values.yaml
@@ -105,9 +105,7 @@ proxy:
       cpu: 50m
       memory: 50Mi
   # -- environment variables
-  env:
-    - name: NGINX_HOST
-      value: 127.0.0.1.nip.io
+  env: []
   # -- (object) liveliness probe config
   livenessProbe:
     # -- enables pods liveness probe

--- a/websight-cms/values.yaml
+++ b/websight-cms/values.yaml
@@ -79,6 +79,7 @@ cms:
     # -- custom CMS ingress annotations
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 5m
+      kubernetes.io/ingress.class: nginx
     # -- cms host
     host: "cms.127.0.0.1.nip.io"
 
@@ -101,9 +102,9 @@ proxy:
       cpu: 50m
       memory: 50Mi
   # -- environment variables
-  env: []
-  # -- Nginx host name used for Nginx config, overwrite it to change the `server_name` in template configurations
-  host: 127.0.0.1.nip.io
+  env:
+    - name: NGINX_HOST
+      value: 127.0.0.1.nip.io
   # -- (object) liveliness probe config
   livenessProbe:
     # -- enables pods liveness probe
@@ -117,6 +118,7 @@ proxy:
   nodeSelector:
   ingress:
     # -- custom ingress annotations
-    annotations: []
-    # -- sites supported by proxy
-    sites: []
+    annotations:
+      kubernetes.io/ingress.class: nginx
+  # -- (object) site configuration, see the `examples/luna-proxy` for more details
+  sites: []

--- a/websight-cms/values.yaml
+++ b/websight-cms/values.yaml
@@ -79,7 +79,6 @@ cms:
     # -- custom CMS ingress annotations
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 5m
-      kubernetes.io/ingress.class: nginx
     # -- cms host
     host: "cms.127.0.0.1.nip.io"
 

--- a/websight-cms/values.yaml
+++ b/websight-cms/values.yaml
@@ -73,14 +73,50 @@ cms:
   debug:
     # -- enables debug on port 5005
     enabled: false
-
-# Nginx Ingress configuration
-ingress:
-  # -- enables nginx ingress
-  enabled: false
-  # -- custom ingress annotations
-  annotations:
-    nginx.ingress.kubernetes.io/proxy-body-size: 5m
-  hosts:
+  ingress:
+    # -- enables CMS ingress
+    enabled: false
+    # -- custom CMS ingress annotations
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-body-size: 5m
     # -- cms host
-    cms: "cms.127.0.0.1.nip.io"
+    host: "cms.127.0.0.1.nip.io"
+
+# WebSight CMS proxy configuration
+proxy:
+  # -- enables proxy
+  enabled: false
+  # -- proxy image repository
+  image:
+    repository: nginx
+    tag: stable-alpine
+  # -- proxy image pull secrets
+  imagePullSecrets: []
+  # -- number of replicas
+  replicas: 1
+  # -- container's resources settings
+  resources:
+    # @ignored in generated docs
+    requests:
+      cpu: 50m
+      memory: 50Mi
+  # -- environment variables
+  env: []
+  # -- Nginx host name used for Nginx config, overwrite it to change the `server_name` in template configurations
+  host: 127.0.0.1.nip.io
+  # -- (object) liveliness probe config
+  livenessProbe:
+    # -- enables pods liveness probe
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  # -- (object) node selector
+  nodeSelector:
+  ingress:
+    # -- custom ingress annotations
+    annotations: []
+    # -- sites supported by proxy
+    sites: []

--- a/websight-cms/values.yaml
+++ b/websight-cms/values.yaml
@@ -117,6 +117,15 @@ proxy:
     timeoutSeconds: 1
     failureThreshold: 3
     successThreshold: 1
+  # -- (object) readiness probe config
+  readinessProbe:
+    # -- enables pods readiness probe
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
   # -- (object) node selector
   nodeSelector:
   ingress:


### PR DESCRIPTION
## Upgrade notes
- `cms` service name has changed back (similar to `1.x` chart version) and now consists of `<release-name>-<chart-name>-cms` (unless release and chart name are the same, then: `websight-cms-cms`.