### PR TITLE
Add TLS support for CMS ingress, replace annotation with ingressClassName, move session cookie settings to ingress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Test with template
         run: helm template --output-dir generated mycms websight-cms
 
+      - name: Run chart helm-unittest
+        run: |
+          cd websight-cms
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git
+          helm unittest -f 'tests/unit/*.yaml' .
+
   verify-installation:
     runs-on: ubuntu-latest
     needs: ['verify-template']

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ The command removes all the Kubernetes components associated with the chart and 
 | cms.ingress.annotations | object | `{"nginx.ingress.kubernetes.io/proxy-body-size":"5m"}` | custom CMS ingress annotations |
 | cms.ingress.enabled | bool | `false` | enables CMS ingress |
 | cms.ingress.host | string | `"cms.127.0.0.1.nip.io"` | cms host |
+| cms.ingress.ingressClassName | string | `"nginx"` | ingress class name |
+| cms.ingress.session.cookie | object | `{"expires":172800,"maxAge":172800}` | nginx ingress affinity settings |
+| cms.ingress.tls.secretName | string | `""` | defines the secret name for the TLS certificate, if set, the TLS will be enabled |
 | cms.livenessProbe.enabled | bool | `true` | enables pods liveness probe |
 | cms.livenessProbe.failureThreshold | int | `3` |  |
 | cms.livenessProbe.initialDelaySeconds | int | `30` |  |
@@ -82,7 +85,6 @@ The command removes all the Kubernetes components associated with the chart and 
 | cms.readinessProbe.timeoutSeconds | int | `10` |  |
 | cms.replicas | int | `1` | number of replicas, mind that `tar` persistence mode will create a StatefulSet, while `mongo` will create a Deployment |
 | cms.resources | object | `{}` | container's resources settings |
-| cms.session.cookie | object | `{"expires":172800,"maxAge":172800}` | ingress nginx.ingress.kubernetes.io/affinity settings |
 | cms.updateStrategy | object | `{}` | update strategy, works only for `mongo` persistence mode |
 | proxy.enabled | bool | `false` | enables proxy |
 | proxy.env | list | `[]` | environment variables |

--- a/websight-cms/templates/cms/cms-ingress.yaml
+++ b/websight-cms/templates/cms/cms-ingress.yaml
@@ -1,24 +1,31 @@
 {{- if .Values.cms.ingress.enabled -}}
+{{- with .Values.cms.ingress }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "websight-cms.component.fullname" (dict "componentName" "cms" "context" $) }}
   annotations:
-    kubernetes.io/ingress.class: nginx
-    {{- if gt (.Values.cms.replicas | int) 1 }}
+    {{- if gt ($.Values.cms.replicas | int) 1 }}
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "websight-cms-sticky"
-    nginx.ingress.kubernetes.io/session-cookie-expires: {{ .Values.cms.session.cookie.expires | quote }}
-    nginx.ingress.kubernetes.io/session-cookie-max-age: {{ .Values.cms.session.cookie.maxAge | quote }}
+    nginx.ingress.kubernetes.io/session-cookie-expires: {{ .session.cookie.expires | quote }}
+    nginx.ingress.kubernetes.io/session-cookie-max-age: {{ .session.cookie.maxAge | quote }}
     {{- end }}
-    {{- if .Values.cms.ingress.annotations }}
-    {{- .Values.cms.ingress.annotations | toYaml | nindent 4 }}
+    {{- if .annotations }}
+    {{- .annotations | toYaml | nindent 4 }}
     {{- end }}
   labels:
     {{- include "websight-cms.component.labels" (dict "componentName" "cms" "context" $) | nindent 4 }}
 spec:
+  ingressClassName: {{ .ingressClassName }}
+  {{- if (.tls).secretName }}
+  tls:
+    - hosts:
+        - {{ tpl .host $ }}
+      secretName: {{ .tls.secretName }}
+  {{- end }}
   rules:
-  - host: {{ tpl .Values.cms.ingress.host . }}
+  - host: {{ tpl .host $ }}
     http:
       paths:
       - pathType: ImplementationSpecific
@@ -28,4 +35,5 @@ spec:
             name: {{ include "websight-cms.component.fullname" (dict "componentName" "cms" "context" $) }}
             port:
               number: 8080
+{{- end }}
 {{- end }}

--- a/websight-cms/tests/unit/cms-ingress-test.yaml
+++ b/websight-cms/tests/unit/cms-ingress-test.yaml
@@ -1,0 +1,85 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+
+suite: test cms ingress
+templates:
+  - templates/cms/cms-ingress.yaml
+tests:
+  # @Test
+  - it: when ingress not enabled then ingress should not be created
+    asserts:
+      - hasDocuments:
+          count: 0
+  # @Test
+  - it: when ingress enabled then ingress should be created with default values
+    set:
+      cms:
+        ingress:
+          enabled: true
+          host: "cms.test.host"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind: 
+          of: Ingress
+      - matchRegex:
+          path: spec.rules[0].host
+          pattern: cms.test.host
+      - matchRegex:
+          path: spec.rules[0].http.paths[0].path
+          pattern: /
+      - matchRegex:
+          path: spec.ingressClassName
+          pattern: nginx
+  # @Test
+  - it: when ingress enabled and custom annotations then ingress should be created with custom annotations
+    set:
+      cms:
+        ingress:
+          enabled: true
+          host: "cms.test.host"
+          annotations:
+            nginx.ingress.kubernetes.io/proxy-body-size: 5m
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            nginx.ingress.kubernetes.io/proxy-body-size: 5m
+  # @Test
+  - it: when more than one CMS replicas then ingress should be configured with sticky session
+    set:
+      cms:
+        replicas: 2
+        ingress:
+          enabled: true
+          host: "cms.test.host"
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            nginx.ingress.kubernetes.io/affinity: "cookie"
+            nginx.ingress.kubernetes.io/session-cookie-name: "websight-cms-sticky"
+            nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
+            nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
+  # @Test
+  - it: when ingress tls secret is set then ingress should be created with tls settings
+    set:
+      cms:
+        ingress:
+          enabled: true
+          host: "unit.test.host"
+          tls:
+            secretName: tls-secret-test
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind: 
+          of: Ingress
+      - matchRegex:
+          path: spec.rules[0].host
+          pattern: unit.test.host
+      - matchRegex:
+          path: spec.tls[0].secretName
+          pattern: tls-secret-test
+      - matchRegex:
+          path: spec.tls[0].hosts[0]
+          pattern: unit.test.host

--- a/websight-cms/values.yaml
+++ b/websight-cms/values.yaml
@@ -16,11 +16,6 @@ cms:
   replicas: 1
   # -- update strategy, works only for `mongo` persistence mode
   updateStrategy: {}
-  session:
-    # -- ingress nginx.ingress.kubernetes.io/affinity settings
-    cookie:
-      expires: 172800
-      maxAge: 172800
   persistence:  
     # -- sets persistence mode, possible options are `tar` or `mongo`
     mode: tar
@@ -78,11 +73,21 @@ cms:
   ingress:
     # -- enables CMS ingress
     enabled: false
+    # -- ingress class name
+    ingressClassName: nginx
     # -- custom CMS ingress annotations
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: 5m
     # -- cms host
     host: "cms.127.0.0.1.nip.io"
+    tls:
+      # -- defines the secret name for the TLS certificate, if set, the TLS will be enabled
+      secretName: ""
+    session:
+      # -- nginx ingress affinity settings
+      cookie:
+        expires: 172800
+        maxAge: 172800
 
 # WebSight CMS proxy configuration
 proxy:


### PR DESCRIPTION
Set of small improvements to CMS's ingress:
- TLS support (via secret)
- deprecated `kubernetes.io/ingress.class` annotation replaced with `spec.ingressClassName`
- session cookie settings moved under `cms.ingress`

## Upgrade notes

### TLS in CMS ingress

To start using TLS directly with chart's CMS ingress create a Secret in the same namespace as you install CMS and configure it via `cms.ingress.tls.secretName` property.

### Session cookies
Update any session cookies settings from:

```yaml
# ...
cms:
  session:
    cookies:
      expires: 172800
      maxAge: 172800
```

to

```yaml
cms:
  ingress:
    session:  # moved from `cms` -> `cms.ingress`
      cookies:
        expires: 172800
        maxAge: 172800
```